### PR TITLE
Fix IP validation and ping command bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1401,6 +1401,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2495,6 +2496,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/tailscale/tailscale-cli.ts
+++ b/src/tailscale/tailscale-cli.ts
@@ -237,7 +237,7 @@ export class TailscaleCLI {
       );
     }
 
-    return await this.executeCommand(["ping", target, "-c", count.toString()]);
+    return await this.executeCommand(["ping", `--c=${count}`, target]);
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types";
 import { isAxiosError } from "axios";
-import * as ipaddr from "ipaddr.js";
+import ipaddrModule from "ipaddr.js";
+const ipaddr = ipaddrModule;
 import { logger } from "./logger.js";
 import { CLIError, TailscaleError } from "./types.js";
 


### PR DESCRIPTION
## Summary

Two bugs fixed:

1. **ESM/CJS interop bug in ipaddr.js import**: `import * as ipaddr from "ipaddr.js"` puts `parse()` on `ipaddr.default` in ESM mode, causing `isValidIPAddress()` to always return `false`. Valid IPs like `100.88.46.13` fall through to the regex guard and throw `"Invalid IPv4 address format"`. Fixed by switching to default import.

2. **Ping CLI command syntax**: Tailscale CLI requires flags before the positional argument using equals syntax (`--c=N <target>`), not space-separated after the target (`<target> -c N`). The old syntax caused `usage: tailscale ping <hostname-or-IP>` errors.

## Changes

- `src/utils.ts`: Changed `import * as ipaddr from "ipaddr.js"` → `import ipaddrModule from "ipaddr.js"`
- `src/tailscale/tailscale-cli.ts`: Changed `["ping", target, "-c", count.toString()]` → `["ping", \`--c=\${count}\`, target]`

## Test plan

- [x] Verified `ipaddr.parse("100.88.46.13")` works with default import in ESM mode
- [x] Verified `tailscale ping --c=3 100.88.46.13` returns pong successfully
- [x] Built and tested end-to-end via MCP tool invocation