### PR TITLE
fix(security): encode API path params, enforce https base URL, evict stale rate-limit buckets

### DIFF
--- a/src/__test__/config/env.test.ts
+++ b/src/__test__/config/env.test.ts
@@ -29,4 +29,27 @@ describe("loadConfig", () => {
       }),
     ).toThrow("HTTP transport requires MCP_HTTP_BEARER_TOKEN");
   });
+
+  test("rejects non-loopback http API base URL", () => {
+    expect(() =>
+      loadConfig({
+        TAILSCALE_API_KEY: "tskey-test",
+        TAILSCALE_API_BASE_URL: "http://api.tailscale.com",
+      }),
+    ).toThrow("TAILSCALE_API_BASE_URL must use https");
+  });
+
+  test("allows loopback http API base URL incl. bracketed IPv6", () => {
+    for (const url of [
+      "http://localhost:8080",
+      "http://127.0.0.1:8080",
+      "http://[::1]:8080",
+    ]) {
+      const config = loadConfig({
+        TAILSCALE_API_KEY: "tskey-test",
+        TAILSCALE_API_BASE_URL: url,
+      });
+      expect(config.TAILSCALE_API_BASE_URL).toBe(url);
+    }
+  });
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,4 @@
+import net from "node:net";
 import { z } from "zod";
 
 export const ToolRiskSchema = z.enum(["read", "write", "admin"]);
@@ -20,13 +21,17 @@ const EnvSchema = z
           if (url.protocol === "https:") {
             return true;
           }
+          if (url.protocol !== "http:") {
+            return false;
+          }
+          // WHATWG URL keeps brackets around IPv6 hosts (e.g. "[::1]").
+          const host = url.hostname.replace(/^\[|\]$/g, "");
           // Permit plain HTTP only for loopback (local dev / mock servers);
           // anything else would transmit the API key / OAuth secret in cleartext.
           return (
-            url.protocol === "http:" &&
-            (url.hostname === "localhost" ||
-              url.hostname === "127.0.0.1" ||
-              url.hostname === "::1")
+            host === "localhost" ||
+            (net.isIPv4(host) && host === "127.0.0.1") ||
+            (net.isIPv6(host) && host === "::1")
           );
         },
         {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -14,6 +14,26 @@ const EnvSchema = z
     TAILSCALE_API_BASE_URL: z
       .string()
       .url()
+      .refine(
+        (value) => {
+          const url = new URL(value);
+          if (url.protocol === "https:") {
+            return true;
+          }
+          // Permit plain HTTP only for loopback (local dev / mock servers);
+          // anything else would transmit the API key / OAuth secret in cleartext.
+          return (
+            url.protocol === "http:" &&
+            (url.hostname === "localhost" ||
+              url.hostname === "127.0.0.1" ||
+              url.hostname === "::1")
+          );
+        },
+        {
+          message:
+            "TAILSCALE_API_BASE_URL must use https (http allowed only for localhost)",
+        },
+      )
       .default("https://api.tailscale.com"),
     TAILSCALE_API_KEY: z.string().optional(),
     TAILSCALE_OAUTH_CLIENT_ID: z.string().optional(),

--- a/src/security/rate-limit.ts
+++ b/src/security/rate-limit.ts
@@ -11,6 +11,14 @@ export function createRateLimitMiddleware(limit = 120, windowMs = 60_000) {
   return (req: Request, res: Response, next: NextFunction) => {
     const key = req.ip ?? req.socket.remoteAddress ?? "unknown";
     const now = Date.now();
+    if (buckets.size > 0) {
+      for (const [bucketKey, bucketValue] of buckets) {
+        if (bucketValue.resetAt <= now) {
+          buckets.delete(bucketKey);
+        }
+      }
+    }
+
     const bucket = buckets.get(key);
 
     if (!bucket || bucket.resetAt <= now) {

--- a/src/tailscale/api-client.ts
+++ b/src/tailscale/api-client.ts
@@ -143,9 +143,12 @@ export class TailscaleApiClient {
   }
 
   async deleteAuthKey(keyId: string): Promise<ApiResult<unknown>> {
-    return this.request(`/tailnet/${this.tailnet}/keys/${keyId}`, {
-      method: "DELETE",
-    });
+    return this.request(
+      `/tailnet/${this.tailnet}/keys/${encodeURIComponent(keyId)}`,
+      {
+        method: "DELETE",
+      },
+    );
   }
 
   async getTailnetSettings(): Promise<ApiResult<unknown>> {
@@ -171,15 +174,21 @@ export class TailscaleApiClient {
   }
 
   async deleteWebhook(webhookId: string): Promise<ApiResult<unknown>> {
-    return this.request(`/tailnet/${this.tailnet}/webhooks/${webhookId}`, {
-      method: "DELETE",
-    });
+    return this.request(
+      `/tailnet/${this.tailnet}/webhooks/${encodeURIComponent(webhookId)}`,
+      {
+        method: "DELETE",
+      },
+    );
   }
 
   async testWebhook(webhookId: string): Promise<ApiResult<unknown>> {
-    return this.request(`/tailnet/${this.tailnet}/webhooks/${webhookId}/test`, {
-      method: "POST",
-    });
+    return this.request(
+      `/tailnet/${this.tailnet}/webhooks/${encodeURIComponent(webhookId)}/test`,
+      {
+        method: "POST",
+      },
+    );
   }
 
   async setDeviceTags(


### PR DESCRIPTION
## Summary

Three low-severity, defense-in-depth hardening fixes found during a security review. No behavior change for correctly-configured deployments.

1. **Path-segment injection (`src/tailscale/api-client.ts`)** — `webhookId` and `keyId` were interpolated into REST paths without encoding (`deviceId` and `tailnet` were already encoded). Now wrapped in `encodeURIComponent` for consistency, preventing a caller-supplied id from altering the request path against `api.tailscale.com`.
2. **Cleartext credential exposure (`src/config/env.ts`)** — `TAILSCALE_API_BASE_URL` only validated URL shape. A misconfigured `http://` base would transmit the API key / OAuth client secret in cleartext. Now requires `https`, permitting plain `http` only for loopback hosts (`localhost`/`127.0.0.1`/`::1`) so local dev and mock servers keep working.
3. **Unbounded rate-limit map (`src/security/rate-limit.ts`)** — expired buckets were never evicted, so the in-memory map could grow unbounded across many distinct client IPs. Expired buckets are now pruned per request.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` for config / security / oauth / api-client / observability — all green
- [x] `biome check` on changed files — clean (formatting matches repo style)
- [x] No regressions vs. `main`: the only failing unit tests (`Logger` suite, 7) fail identically on a pristine `main` checkout and are unrelated to these changes (appears environment/Windows-specific).

Found via an independent security review; the codebase was otherwise solid (array-arg exec, constant-time token compare, redaction, loopback-bound HTTP transport). A separate PR will follow for removing the unused legacy server stack.