### PR TITLE
fix(mcp): don't mask tool errors with non-conforming structuredContent

### DIFF
--- a/src/__test__/observability/errors.test.ts
+++ b/src/__test__/observability/errors.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { AppError, toMcpError } from "../../observability/errors.js";
+
+describe("toMcpError", () => {
+  test("AppError surfaces safeMessage without structuredContent", () => {
+    const result = toMcpError(
+      new AppError(
+        "Tool requires admin risk level",
+        "risk_level_denied",
+        403,
+        "Tool requires admin risk level",
+      ),
+    );
+    expect(result.isError).toBe(true);
+    // Must NOT carry structuredContent: it would violate the tool's
+    // advertised outputSchema and mask the real error on the client.
+    expect("structuredContent" in result).toBe(false);
+    expect(result.content).toEqual([
+      { type: "text", text: "Tool requires admin risk level" },
+    ]);
+  });
+
+  test("generic Error surfaces its message without structuredContent", () => {
+    const result = toMcpError(new Error("boom"));
+    expect(result.isError).toBe(true);
+    expect("structuredContent" in result).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "boom" }]);
+  });
+
+  test("non-Error falls back to a safe message", () => {
+    const result = toMcpError("weird");
+    expect(result.isError).toBe(true);
+    expect("structuredContent" in result).toBe(false);
+    expect(result.content).toEqual([
+      { type: "text", text: "Operation failed" },
+    ]);
+  });
+});

--- a/src/observability/errors.ts
+++ b/src/observability/errors.ts
@@ -12,10 +12,16 @@ export class AppError extends Error {
 }
 
 export function toMcpError(error: unknown): CallToolResult {
+  // NOTE: tools advertise an `outputSchema`. MCP clients validate a result's
+  // `structuredContent` against that schema even on error results. An error
+  // shape (`{ error: ... }`) does not conform to schemas like
+  // `{ data }`/`{ message }`, so attaching it made every failed call surface
+  // the opaque "structured content does not match the output schema" and
+  // hid the real error. Error results intentionally omit `structuredContent`;
+  // the actionable message stays in the text content.
   if (error instanceof AppError) {
     return {
       isError: true,
-      structuredContent: { error: { code: error.code } },
       content: [{ type: "text", text: error.safeMessage }],
     };
   }
@@ -23,14 +29,12 @@ export function toMcpError(error: unknown): CallToolResult {
   if (error instanceof Error) {
     return {
       isError: true,
-      structuredContent: { error: { code: "operation_failed" } },
       content: [{ type: "text", text: error.message }],
     };
   }
 
   return {
     isError: true,
-    structuredContent: { error: { code: "internal_error" } },
     content: [{ type: "text", text: "Operation failed" }],
   };
 }


### PR DESCRIPTION
## Summary

Every tool is registered with an `outputSchema` (`{ data }`, `{ message }`, …). `toMcpError` attaches `structuredContent: { error: { code } }` to failure results. The server SDK skips output validation when `isError` is set, **but MCP clients validate a result's `structuredContent` against the advertised output schema regardless of `isError`**, and the error shape conforms to none of the declared schemas.

Net effect: every failed tool call surfaces the opaque **`structured content does not match the tool's output schema`**, and the real error is hidden. Reads appear fine; all write tools (`manage_acl`, `manage_policy_file`, `manage_keys`, `manage_dns`, …) look silently broken — e.g. the `requireRisk` gate's `Tool requires write/admin risk level`, or a genuine Tailscale API error, never reaches the caller.

## Fix

Error results omit `structuredContent`. Per MCP semantics, error results aren't expected to satisfy `outputSchema`; the actionable message is carried in the text `content` as before. No change to success results.

## Test plan

- [x] New `src/__test__/observability/errors.test.ts` asserting `toMcpError` returns `isError: true`, no `structuredContent`, and the real message in text content (AppError / Error / non-Error).
- [x] `bun run typecheck` clean
- [x] `biome check` clean on changed files
- [x] Repro: with default `TAILSCALE_ALLOWED_TOOL_RISK=read`, `manage_policy_file update` returned the schema error; after the fix it returns `Tool requires write risk level`.