### PR TITLE
fix(mcp): allow omitted routes in device output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,12 +25,12 @@
     },
   },
   "overrides": {
-    "@hono/node-server": "1.19.14",
+    "@hono/node-server": "2.0.11",
     "ajv": "8.20.0",
     "brace-expansion": "5.0.7",
-    "fast-uri": "4.1.0",
+    "fast-uri": "4.1.1",
     "form-data": "4.0.6",
-    "hono": "4.12.25",
+    "hono": "4.12.31",
     "ip-address": "10.2.0",
     "path-to-regexp": "8.4.2",
     "qs": "6.15.3",
@@ -106,7 +106,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@hono/node-server": ["@hono/node-server@2.0.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -212,7 +212,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@4.1.0", "", {}, "sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA=="],
+    "fast-uri": ["fast-uri@4.1.1", "", {}, "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ=="],
 
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
 
@@ -242,7 +242,7 @@
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
-    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+    "hono": ["hono@4.12.31", "", {}, "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg=="],
 
     "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
   "overrides": {
     "@hono/node-server": "2.0.11",
     "ajv": "8.20.0",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "fast-uri": "4.1.1",
     "form-data": "4.0.6",
     "hono": "4.12.31",
@@ -150,7 +150,7 @@
 
     "body-parser": ["body-parser@2.2.1", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/package.json
+++ b/package.json
@@ -79,10 +79,10 @@
     "typescript": "6.0.3"
   },
   "overrides": {
-    "@hono/node-server": "1.19.14",
+    "@hono/node-server": "2.0.11",
     "ajv": "8.20.0",
-    "fast-uri": "4.1.0",
-    "hono": "4.12.25",
+    "fast-uri": "4.1.1",
+    "hono": "4.12.31",
     "ip-address": "10.2.0",
     "path-to-regexp": "8.4.2",
     "brace-expansion": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "hono": "4.12.31",
     "ip-address": "10.2.0",
     "path-to-regexp": "8.4.2",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "form-data": "4.0.6",
     "qs": "6.15.3"
   }

--- a/src/__test__/mcp/device-tools.test.ts
+++ b/src/__test__/mcp/device-tools.test.ts
@@ -8,6 +8,8 @@
  */
 import { describe, expect, test } from "bun:test";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { DevicesOutputSchema } from "../../mcp/schemas/tool-results.js";
 import { registerDeviceTools } from "../../mcp/tools/devices.js";
 import {
   CapturingServer,
@@ -30,6 +32,18 @@ function buildServer(risk: "read" | "write" | "admin" = "admin") {
 }
 
 describe("list_devices handler", () => {
+  test("route fields are optional in the output JSON Schema", () => {
+    const schema = z.toJSONSchema(DevicesOutputSchema) as unknown as {
+      properties: {
+        devices: { items: { required?: string[] } };
+      };
+    };
+    const required = schema.properties.devices.items.required ?? [];
+
+    expect(required).not.toContain("advertisedRoutes");
+    expect(required).not.toContain("enabledRoutes");
+  });
+
   test("success path — returns device list content", async () => {
     const { server, svc } = buildServer("read");
     svc.listDevices = async () => [sampleDevice];

--- a/src/__test__/mcp/device-tools.test.ts
+++ b/src/__test__/mcp/device-tools.test.ts
@@ -35,11 +35,28 @@ describe("list_devices handler", () => {
   test("route fields are optional in the output JSON Schema", () => {
     const schema = z.toJSONSchema(DevicesOutputSchema) as unknown as {
       properties: {
-        devices: { items: { required?: string[] } };
+        devices: {
+          items: {
+            properties: Record<
+              string,
+              { type?: string; items?: { type?: string } }
+            >;
+            required?: string[];
+          };
+        };
       };
     };
-    const required = schema.properties.devices.items.required ?? [];
+    const itemSchema = schema.properties.devices.items;
+    const required = itemSchema.required ?? [];
 
+    expect(itemSchema.properties.advertisedRoutes).toMatchObject({
+      type: "array",
+      items: { type: "string" },
+    });
+    expect(itemSchema.properties.enabledRoutes).toMatchObject({
+      type: "array",
+      items: { type: "string" },
+    });
     expect(required).not.toContain("advertisedRoutes");
     expect(required).not.toContain("enabledRoutes");
   });

--- a/src/mcp/schemas/tool-results.ts
+++ b/src/mcp/schemas/tool-results.ts
@@ -1,8 +1,13 @@
 import { z } from "zod";
 import { DeviceSummarySchema, TailnetSummarySchema } from "./tailscale.js";
 
+const ListedDeviceSummarySchema = DeviceSummarySchema.extend({
+  advertisedRoutes: z.array(z.string()).optional(),
+  enabledRoutes: z.array(z.string()).optional(),
+});
+
 export const DevicesOutputSchema = z.object({
-  devices: z.array(DeviceSummarySchema),
+  devices: z.array(ListedDeviceSummarySchema),
 });
 
 export const MessageOutputSchema = z.object({


### PR DESCRIPTION
## What
- Make route fields optional in the `list_devices` output schema and add regression coverage.
- Refresh vulnerable transitive overrides required by CI audit.

## Why
`includeRoutes: false` omits route fields, causing schema-validating clients to reject valid responses. The previous exact dependency pins also fail the current moderate-level audit.

## Test
- Full CI command sequence
- HTTP health smoke

Fixes #145

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow omitted routes in `DevicesOutputSchema` device output
> Adds optional `advertisedRoutes` and `enabledRoutes` fields to the device summary schema used in the `list_devices` MCP tool. A new `ListedDeviceSummarySchema` extends `DeviceSummarySchema` with these two optional `array<string>` properties, so device objects that include route data pass validation without requiring it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 448efb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->